### PR TITLE
Bug: IndicationInstance 지원 중단에 따른 IndicationNodeFactory로의 마이그레이션 작업

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -105,6 +105,9 @@ dependencies {
 
     //Gson 종속성 추가
     implementation("com.google.code.gson:gson:2.10.1")
+
+    //권한 요청 관련 모듈
+    implementation("com.google.accompanist:accompanist-permissions:0.35.1-alpha")
 }
 
 kapt {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <!-- Camera 권한 설정 -->
+    <uses-permission android:name="android.permission.CAMERA"/>
+    <!-- Camera 가 필수 기능이 아님을 명시함 -->
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
 
     <uses-permission android:name="android.permission.INTERNET"/>
 

--- a/app/src/main/java/gdsc/solutionchallenge/saybetter/saybetterlearner/ui/menu/MenuActivity.kt
+++ b/app/src/main/java/gdsc/solutionchallenge/saybetter/saybetterlearner/ui/menu/MenuActivity.kt
@@ -42,7 +42,9 @@ import gdsc.solutionchallenge.saybetter.saybetterlearner.ui.chatbot.ChatBotActiv
 import gdsc.solutionchallenge.saybetter.saybetterlearner.ui.theme.MainGreen
 import gdsc.solutionchallenge.saybetter.saybetterlearner.ui.theme.White
 import gdsc.solutionchallenge.saybetter.saybetterlearner.ui.videocall.VideoCallActivity
+import gdsc.solutionchallenge.saybetter.saybetterlearner.utils.FeatureThatRequiresCameraPermission
 import gdsc.solutionchallenge.saybetter.saybetterlearner.utils.customclick.CustomClickEvent
+
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -79,6 +81,12 @@ class MenuActivity: ComponentActivity()  {
         mainServiceRepository.startService(userid!!)
     }
 
+    //Video call 클릭되었을 때
+    @Composable
+    private fun StartVideoCall(userid : String) {
+        FeatureThatRequiresCameraPermission()
+    }
+
     @Preview(widthDp = 1280, heightDp = 800)
     @Composable
     fun MenuPreview() {
@@ -99,7 +107,8 @@ class MenuActivity: ComponentActivity()  {
     @Composable
     fun MenuBar(menuList : List<menu>) {
         Box {
-            Column (modifier = Modifier.fillMaxWidth()
+            Column (modifier = Modifier
+                .fillMaxWidth()
                 .padding(top = 100.dp),
                 horizontalAlignment = Alignment.CenterHorizontally
             ){
@@ -120,6 +129,7 @@ class MenuActivity: ComponentActivity()  {
                             when (menuEntity.title) {
                                 "그림 상징 의사소통" -> {
                                     intent = Intent(this@MenuActivity, VideoCallActivity::class.java)
+                                    //StartVideoCall(userid = "helloid")
                                 }
                                 "AI 챗봇" -> {
                                     intent = Intent(this@MenuActivity, ChatBotActivity::class.java)
@@ -159,7 +169,7 @@ class MenuActivity: ComponentActivity()  {
             Text(text = menuEntity.title,
                 fontSize = 20.sp,
                 fontWeight = FontWeight.W600)
-        }
+            }
     }
 }
 

--- a/app/src/main/java/gdsc/solutionchallenge/saybetter/saybetterlearner/utils/Extensions.kt
+++ b/app/src/main/java/gdsc/solutionchallenge/saybetter/saybetterlearner/utils/Extensions.kt
@@ -1,0 +1,41 @@
+package gdsc.solutionchallenge.saybetter.saybetterlearner.utils
+
+import android.util.Log
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.isGranted
+import com.google.accompanist.permissions.rememberPermissionState
+import com.google.accompanist.permissions.shouldShowRationale
+
+@OptIn(ExperimentalPermissionsApi::class)
+@Composable
+fun ComponentActivity.FeatureThatRequiresCameraPermission() {
+    //카메라 권한 상태
+    val cameraPermissionState = rememberPermissionState(
+        permission = android.Manifest.permission.CAMERA
+    )
+
+    if(cameraPermissionState.status.isGranted) {
+        Text(text = "카메라 권한이 부여됨")
+        Log.d("permission", "camera permission granted")
+    } else {
+        Column {
+            val textToShow = if(cameraPermissionState.status.shouldShowRationale) {
+                // 사용자가 권한 요청을 거부했지만 근거를 제시할 수 있는 경우, 앱에 이 권한이 필요한 이유를 친절하게 설명합니다.
+                "이 앱은 카메라가 중요합니다. 권한을 부여해주세요."
+            } else {
+                // 사용자가 이 기능을 처음 사용하거나, 사용자에게 이 권한을 다시 묻고 싶지 않은 경우 권한이 필요하다고 설명합니다.
+                "이 기능을 사용하려면 카메라 권한이 필요합니다. " +
+                        "권한을 부여해주세요."
+            }
+            Text(textToShow)
+            Button(onClick = { cameraPermissionState.launchPermissionRequest() }) {
+                Text("권한 요청")
+            }
+        }
+    }
+}

--- a/app/src/main/java/gdsc/solutionchallenge/saybetter/saybetterlearner/utils/customclick/CustomClickEvent.kt
+++ b/app/src/main/java/gdsc/solutionchallenge/saybetter/saybetterlearner/utils/customclick/CustomClickEvent.kt
@@ -1,32 +1,38 @@
 package gdsc.solutionchallenge.saybetter.saybetterlearner.utils.customclick
 
+import android.util.Log
 import androidx.compose.foundation.Indication
-import androidx.compose.foundation.IndicationInstance
+import androidx.compose.foundation.IndicationNodeFactory
 import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.node.DelegatableNode
+import androidx.compose.ui.node.DrawModifierNode
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
-object CustomClickEvent : Indication {
-    private class DefaultDebugIndicationInstance(
-        private val isPressed: State<Boolean>,
-    ) : IndicationInstance {
-        override fun ContentDrawScope.drawIndication() {
-            drawContent()
-            if (isPressed.value) {
-                drawRect(color = Color.Gray.copy(alpha = 0f), size = size)
-            }
+object CustomClickEvent : IndicationNodeFactory {
+    private class DefaultDebugIndicationNode(
+        private val interactionSource: InteractionSource,
+    ) : Modifier.Node(), DrawModifierNode {
+        override fun ContentDrawScope.draw() {
+            Log.d("indication", "contentDrawScope")
+            drawRect(color = Color.Gray.copy(alpha = 0f), size = size)
+            this@draw.drawContent()
         }
     }
 
-    @Composable
-    override fun rememberUpdatedInstance(interactionSource: InteractionSource): IndicationInstance {
-        val isPressed = interactionSource.collectIsPressedAsState()
-        return remember(interactionSource) {
-            DefaultDebugIndicationInstance(isPressed)
-        }
+    override fun create(interactionSource: InteractionSource): DelegatableNode {
+        return DefaultDebugIndicationNode(interactionSource)
     }
+
+    override fun equals(other: Any?): Boolean = other === this
+
+    override fun hashCode(): Int = -1
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,3 +9,4 @@ plugins {
     // Add the dependency for the Google services Gradle plugin
     id("com.google.gms.google-services") version "4.3.15" apply false
 }
+


### PR DESCRIPTION
## 🔎 작업 내용

- CustomClick.kt 파일에서 상징 터치 상호작용 구현을 위한 코드가 Compose 1.7 이상 버전에서 hard deprecate 되어 컴파일 단계에서 오류 발생
- [공식 문서 마이그레이션 가이드](https://developer.android.com/develop/ui/compose/touch-input/user-interactions/migrate-indication-ripple?hl=ko)를 참고하여 마이그레이션 완료

  <br/>

## ➕ 이슈 링크

- 연관된 이슈 없음 (원래는 버그 발견 -> 이슈 작성 -> 버그 수정 -> PR에서 이슈 연결 -> 이슈 닫기 순서대로 진행되어야 하나 편의상 생략)

<br/>
