### PR TITLE
🐛 Bug: currentReceivedModel Type 수정

### DIFF
--- a/app/src/main/java/gdsc/solutionchallenge/saybetter/saybetterlearner/ui/menu/MenuActivity.kt
+++ b/app/src/main/java/gdsc/solutionchallenge/saybetter/saybetterlearner/ui/menu/MenuActivity.kt
@@ -3,6 +3,7 @@ package gdsc.solutionchallenge.saybetter.saybetterlearner.ui.menu
 import android.Manifest
 import android.content.Intent
 import android.os.Bundle
+import android.provider.ContactsContract.Data
 import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -69,7 +70,8 @@ class MenuActivity: ComponentActivity() , MainService.CallEventListener {
 
     private var userId: String? = null
     private val testUser: String = "testUser1"
-    private var currentReceivedModel: DataModel? = null
+//    private var currentReceivedModel: DataModel? = null
+    private var receivedModelState: MutableState<DataModel?> = mutableStateOf(null)
     private val customAlertDialogState = mutableStateOf(TestDialogState())
 
     //Hilt 종속성 주입
@@ -84,9 +86,9 @@ class MenuActivity: ComponentActivity() , MainService.CallEventListener {
         setContent {
             MenuView(
                 resetDialogState = {resetDialogState(customAlertDialogState)},
-                startVideoCall = {testUser, isCaller -> startVideoCall(testUser, isCaller) },
-                user = userId!!,
-                currentReceivedModel = currentReceivedModel,
+                startVideoCall = {targetUser, isCaller -> startVideoCall(targetUser, isCaller) },
+                targetUser = userId!!,
+                currentReceivedModel = receivedModelState,
                 customAlertDialogState = customAlertDialogState,
                 onClickChatbot = {
                     intent = Intent(this@MenuActivity, ChatBotActivity::class.java)
@@ -110,7 +112,9 @@ class MenuActivity: ComponentActivity() , MainService.CallEventListener {
     }
 
     private fun init(){
-        userId = intent.getStringExtra("userid")!!
+        userId = intent.getStringExtra("userid")
+        if(userId == null) finish()
+
         MainService.listener = this
         startMyService()
     }
@@ -134,7 +138,7 @@ class MenuActivity: ComponentActivity() , MainService.CallEventListener {
     }
     override fun onCallReceived(model: DataModel) {
         Log.d("MainService", "call receive by ${model.sender}")
-        this.currentReceivedModel = model
+        receivedModelState.value = model
 
         customAlertDialogState.value = TestDialogState(
             isClick = true,

--- a/app/src/main/java/gdsc/solutionchallenge/saybetter/saybetterlearner/ui/menu/MenuView.kt
+++ b/app/src/main/java/gdsc/solutionchallenge/saybetter/saybetterlearner/ui/menu/MenuView.kt
@@ -29,12 +29,13 @@ import gdsc.solutionchallenge.saybetter.saybetterlearner.utils.permission.checkA
 @Composable
 fun MenuPreview() {
     val mockDialogState = remember { mutableStateOf(MenuActivity.TestDialogState()) }
+    val receivedModelState: MutableState<DataModel?> = remember{ mutableStateOf(null) }
 
     MenuView(
         resetDialogState = { mockDialogState.value = MenuActivity.TestDialogState() },
         startVideoCall = { _, _ -> },
-        user = "testUser1",
-        currentReceivedModel =null,
+        targetUser = "testUser1",
+        currentReceivedModel = receivedModelState,
         customAlertDialogState = mockDialogState,
         onClickChatbot = { /* Handle chatbot click */ },
         onClickSetting = { /* Handle setting click */ },
@@ -46,8 +47,8 @@ fun MenuPreview() {
 fun MenuView(
     resetDialogState: () -> Unit,
     startVideoCall: (String, Boolean) -> Unit,
-    user: String,
-    currentReceivedModel : DataModel?,
+    targetUser: String,
+    currentReceivedModel : MutableState<DataModel?>,
     customAlertDialogState: MutableState<MenuActivity.TestDialogState>,
     onClickChatbot: () -> Unit,
     onClickSetting: () -> Unit,
@@ -71,8 +72,9 @@ fun MenuView(
         /** 권한 요청시 동의 했을 경우 **/
         if (areGranted) {
             Log.d("test5", "권한이 동의되었습니다.")
+            Log.d("test5", currentReceivedModel.value?.sender!!)
             resetDialogState()
-            startVideoCall(user, isCaller!!)
+            startVideoCall(currentReceivedModel.value?.sender!!, isCaller!!)
         }
         /** 권한 요청시 거부 했을 경우 **/
         /** 권한 요청시 거부 했을 경우 **/
@@ -101,8 +103,9 @@ fun MenuView(
                         permissions,
                         launcherMultiplePermissions,
                         onPermissionsGranted = {    //권한이 이미 다 있을 때
+                            Log.d("MenuViewState", currentReceivedModel.toString())
                             resetDialogState()
-                            startVideoCall(currentReceivedModel?.sender!!, isCaller!!)
+                            startVideoCall(currentReceivedModel.value?.sender!!, isCaller!!)
                         }
                     )
                 },
@@ -124,7 +127,7 @@ fun MenuView(
                             permissions,
                             launcherMultiplePermissions,
                             onPermissionsGranted = {    //권한이 이미 다 있을 때
-                                startVideoCall(user, isCaller!!)
+                                startVideoCall("helloYI", isCaller!!) // 타겟이 들어가야함
                             }
                         )
                     }


### PR DESCRIPTION
#44

## 🔎 작업 내용

Learner-APP에서 Educator-APP의 요청을 받아 VideoCall에 진입하는 과정에서 `currentReceivedModel` 값이 `null`로 전달되어 `NullPointerException` 때문에 팅기는 현상이 있었는데, 해당 상태값을 `MutableState<DataModel?>` 형태로 재정의하여 해결 하였습니다.

  <br/>

## ➕ 이슈 링크

- [Android-Learner-APP #44 ](https://github.com/Say-Better/Android-Learner-APP/issues/44)

<br/>
